### PR TITLE
Fixed P2P connect cycle

### DIFF
--- a/simulations/P2PShowcase/omnetpp.ini
+++ b/simulations/P2PShowcase/omnetpp.ini
@@ -28,7 +28,9 @@ network = P2PNetwork
 
 ## Discovery Services
 *.*.discoveryService[0].userAppName = "HardcodedDiscoveryService"
+*.*.discoveryService[1].app.addressList = ["10.0.0.2"]
 *.*.discoveryService[0].pid = 1
+
 *.*.discoveryService[1].userAppName = "DnsDiscoveryService"
 *.*.discoveryService[1].app.dnsSeed = "p2p.mainnet.com"
 *.*.discoveryService[1].app.dnsIp = "10.0.0.1"

--- a/src/s2f/apps/p2p/P2P.h
+++ b/src/s2f/apps/p2p/P2P.h
@@ -23,11 +23,9 @@ class P2P : public AppBase, public AppBase::ICallback
   protected:
     enum P2PEvent
     {
-        NODE_UP = 4,     //!< Post-startup action for protocol implementation
-        PEER_DISCOVERY,  //!< Peer discovery handling for protocol implementation
-        PEER_CONNECTION, //!< Connection to peer candidates from discovery
-                         //!< process
-        CONNECTED        //!< Node is ready and connected to the network
+        PEER_DISCOVERY,  //!< Get addresses using discovery services
+        PEER_CONNECTION, //!< Connect to addreesses from services
+        CONNECTED        //!< Node is ready to handle petitions
     };
 
     std::map<int, Peer *> peerData; //!< Peer data
@@ -101,6 +99,8 @@ class P2P : public AppBase, public AppBase::ICallback
 
     /**
      * Handle hook for messages sent by this module.
+     *
+     * TODO: in the PEER_CONNECTION status,
      *
      * @param msg   Message to process.
      */

--- a/src/s2f/apps/p2p/discovery/hardcoded/HardcodedDiscoveryService.ned
+++ b/src/s2f/apps/p2p/discovery/hardcoded/HardcodedDiscoveryService.ned
@@ -5,5 +5,5 @@ import s2f.apps.p2p.discovery.InnerThread;
 simple HardcodedDiscoveryService extends InnerThread {
 	parameters:
 	  @class(HardcodedDiscoveryService);
-    object addressList = default(["10.0.0.1", "10.0.0.2"]); // List of strings with IP Addresses.
+    object addressList = default([]); // List of strings with IP Addresses.
 }


### PR DESCRIPTION
The hardcoded address variant pointed to an IP address that did not have `listeningPort` open, causing the program to hang on an `RST` signal received.