### PR TITLE
Emergency P2P Flow Fix

### DIFF
--- a/simulations/P2PShowcase/P2PSimpleNetwork.ned
+++ b/simulations/P2PShowcase/P2PSimpleNetwork.ned
@@ -21,6 +21,7 @@ import s2f.architecture.net.stack.proxy.ServiceTable;
 import s2f.architecture.net.stack.resolver.DnsResolver;
 import s2f.architecture.dns.resolver.DnsResolverServer;
 import s2f.architecture.dns.DnsSimplified;
+import s2f.architecture.p2p.pow.nodes.FullNode;
 import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
 import inet.node.ethernet.Eth10M;
 import inet.node.ethernet.EthernetSwitch;
@@ -35,7 +36,7 @@ module PeerNode extends StandardHost
             @display("p=932.554,60.966003");
         }
         discoveryService[numServices]: UserAppModule;
-
+		node: FullNode;
         resolver: DnsResolver {
             @display("p=1106.42,60.966003");
         }

--- a/simulations/P2PShowcase/omnetpp.ini
+++ b/simulations/P2PShowcase/omnetpp.ini
@@ -23,7 +23,7 @@ network = P2PNetwork
 *.*.protocol.userAppName = "PowP2P"
 *.*.protocol.app.listeningPort = 8333
 *.*.protocol.app.discoveryPath = "^.^.discoveryService"
-*.*.protocol.app.internalPath = "^.^.node"
+*.*.protocol.app.nodePath = "^.^.node"
 *.*.protocol.pid = 0
 
 ## Discovery Services

--- a/src/s2f/apps/p2p/P2P.h
+++ b/src/s2f/apps/p2p/P2P.h
@@ -23,9 +23,9 @@ class P2P : public AppBase, public AppBase::ICallback
   protected:
     enum P2PEvent
     {
-        PEER_DISCOVERY,  //!< Get addresses using discovery services
-        PEER_CONNECTION, //!< Connect to addreesses from services
-        CONNECTED        //!< Node is ready to handle petitions
+        PEER_DISCOVERY = SEND_DELAYED + 1, //!< Get addresses using discovery services
+        PEER_CONNECTION,                   //!< Connect to addreesses from services
+        CONNECTED                          //!< Node is ready to handle petitions
     };
 
     std::map<int, Peer *> peerData; //!< Peer data

--- a/src/s2f/apps/p2p/P2P.ned
+++ b/src/s2f/apps/p2p/P2P.ned
@@ -23,10 +23,10 @@ module P2P extends AppBase {
     int discoveryAttempts = 3;
     int discoveryThreshold = 5;
     int listeningPort;
-    
-    string internalPath = default("");
+
+    string nodePath = default("");
     string discoveryPath = default("");
-    
+
     gates:
         input internal @directIn; // for communication with other internal modules
         input discovery @directIn; // for communication with discovery services

--- a/src/s2f/architecture/p2p/pow/IPowMsgActions.h
+++ b/src/s2f/architecture/p2p/pow/IPowMsgActions.h
@@ -34,16 +34,9 @@ namespace s2f::p2p::pow
 
     struct ActionSchedule
     {
-        int id;            //!< Message identifier
         short eventKind;   //<! Event type to schedule
         int eventDelayMin; //<! Minimum delay for self event
         int eventDelayMax; //<! Maximum delay for self event
     };
-
-    struct ActionCancel
-    {
-        int id; //!< Message identifier
-    };
-
 }
 #endif

--- a/src/s2f/architecture/p2p/pow/PowP2P.h
+++ b/src/s2f/architecture/p2p/pow/PowP2P.h
@@ -23,12 +23,12 @@ namespace s2f::p2p::pow
     class PowP2P : public P2P
     {
       protected:
-        PowPeer self;                                                      //!< Representation of this node
-        std::map<int, cMessage *> peerConnection;                          //!< Peer event handlers
-        std::map<std::string, std::unique_ptr<IPowMsgConsumer>> consumers; //!< Message handlers
-        std::map<std::string, std::unique_ptr<IPowMsgProducer>> producers; //!< Message handlers
-        std::map<int, PowPeer *> &powPeers =
-            reinterpret_cast<std::map<int, PowPeer *> &>(peerData); //!< Peer list in PowNetworkPeer format
+        PowPeer self;                                                                                //!< Representation of this node
+        std::map<int, cMessage *> peerConnection;                                                    //!< Peer event handlers
+        std::map<std::string, std::unique_ptr<IPowMsgConsumer>> consumers;                           //!< Message handlers
+        std::map<std::string, std::unique_ptr<IPowMsgProducer>> producers;                           //!< Message handlers
+        std::map<int, PowPeer *> &powPeers = reinterpret_cast<std::map<int, PowPeer *> &>(peerData); //!< Peer list in PowNetworkPeer format
+        cGate *node{};                                                                               //!< Processing node, SPV client, etc
 
         // ------------------------------------------------------------- //
         //                           OVERRIDES                           //

--- a/src/s2f/architecture/p2p/pow/PowP2P.ned
+++ b/src/s2f/architecture/p2p/pow/PowP2P.ned
@@ -16,9 +16,8 @@
 package s2f.architecture.p2p.pow;
 import s2f.apps.p2p.P2P;
 
-module PowP2P extends P2P
-{
-    parameters:
-    	@class(PowP2P);
-    	listeningPort=8333;
+module PowP2P extends P2P {
+  parameters:
+    @class(PowP2P);
+    listeningPort=8333;
 }

--- a/src/s2f/architecture/p2p/pow/consumers/AddressMsgConsumer.cc
+++ b/src/s2f/architecture/p2p/pow/consumers/AddressMsgConsumer.cc
@@ -12,7 +12,7 @@ int findIpInPeers(std::map<int, PowPeer *> &peers, inet::L3Address ip)
 
 std::vector<IPowMsgDirective> AddressMsgConsumer::handleMessage(IPowMsgContext &ictx)
 {
-    ActionOpen action{};
+    ActionOpen *action = new ActionOpen({.peers = {}});
     auto payload = ictx.msg->peekData<Address>();
 
     for (int i = 0; i < payload->getIpAddressArraySize(); i++)
@@ -22,8 +22,8 @@ std::vector<IPowMsgDirective> AddressMsgConsumer::handleMessage(IPowMsgContext &
         if (p->getIpAddress() == ictx.self.getIpAddress() || findIpInPeers(ictx.peers, p->getIpAddress()))
             delete p;
         else
-            action.peers.push_back(p);
+            action->peers.push_back(p);
     }
 
-    return {{.action = OPEN, .data = static_cast<void *>(&action)}};
+    return {{.action = OPEN, .data = static_cast<void *>(action)}};
 }

--- a/src/s2f/architecture/p2p/pow/consumers/PongMsgConsumer.cc
+++ b/src/s2f/architecture/p2p/pow/consumers/PongMsgConsumer.cc
@@ -6,16 +6,14 @@ using namespace s2f::p2p::pow;
 
 std::vector<IPowMsgDirective> PongMsgConsumer::handleMessage(struct IPowMsgContext &ictx)
 {
-    ActionCancel oldMsg = {.id = ictx.sockFd};
-    ActionSchedule newMsg = {
-        .id = ictx.sockFd,
+    ActionSchedule *newMsg = new ActionSchedule({
         .eventKind = pow::SEND_PING,
         .eventDelayMin = pow::PING_POLLING_MIN,
         .eventDelayMax = pow::PING_POLLING_MAX,
-    };
+    });
 
     return {
-        {.action = CANCEL, .data = static_cast<void *>(&oldMsg)},
-        {.action = SCHEDULE, .data = static_cast<void *>(&newMsg)},
+        {.action = CANCEL, .data = nullptr},
+        {.action = SCHEDULE, .data = static_cast<void *>(newMsg)},
     };
 }

--- a/src/s2f/architecture/p2p/pow/consumers/VerackMsgConsumer.cc
+++ b/src/s2f/architecture/p2p/pow/consumers/VerackMsgConsumer.cc
@@ -5,14 +5,13 @@ using namespace s2f::p2p::pow;
 std::vector<IPowMsgDirective> VerackMsgConsumer::handleMessage(struct IPowMsgContext &ictx)
 {
 
-    ActionSchedule newMsg = {
-        .id = ictx.sockFd,
+    ActionSchedule *newMsg = new ActionSchedule({
         .eventKind = pow::SEND_PING,
         .eventDelayMin = pow::PING_POLLING_MIN,
         .eventDelayMax = pow::PING_POLLING_MAX,
-    };
+    });
     return {
-        {.action = SCHEDULE, .data = static_cast<void *>(&newMsg)},
+        {.action = SCHEDULE, .data = static_cast<void *>(newMsg)},
     };
 }
 

--- a/src/s2f/architecture/p2p/pow/messages/Address.msg
+++ b/src/s2f/architecture/p2p/pow/messages/Address.msg
@@ -16,6 +16,5 @@ namespace s2f::p2p::pow;
 class Address extends inet::FieldsChunk
 {
 	  chunkLength = inet::B(20); // Packet length
-    uint16_t ipAddressCount;
 	  PowPeer *ipAddress[]; 
 }

--- a/src/s2f/architecture/p2p/pow/nodes/FullNode.cc
+++ b/src/s2f/architecture/p2p/pow/nodes/FullNode.cc
@@ -27,7 +27,8 @@ void FullNode::initialize(int stage)
 
 void FullNode::handleMessage(omnetpp::cMessage *msg)
 {
-    delete msg;
+    if (msg)
+        delete msg;
     return;
 }
 

--- a/src/s2f/architecture/p2p/pow/nodes/FullNode.ned
+++ b/src/s2f/architecture/p2p/pow/nodes/FullNode.ned
@@ -4,6 +4,5 @@ simple FullNode
 	parameters:
 	    @class(FullNode);
   gates:
-      input in;
-      output out;
+      input internal @directIn;
 }


### PR DESCRIPTION
`PEER_DISCOVERY` was set to the same value as `EXEC_START` which made an endless loop of self-events and the connection error pointless.

There was also an issue of converting function-scoped variables to `void*`, which implied all data was lost when passed back to the module.